### PR TITLE
Instanced supervisor

### DIFF
--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -85,7 +85,11 @@ defmodule Populator.Helpers do
     name are not returned. List is sorted. Options al passed to `children_data/2`.
   """
   def children_names(supervisor) do
-    supervisor |> Supervisor.which_children |> Enum.map(fn (x) -> {name, _, _, _} = x; name end) |> Enum.sort
+    supervisor
+      |> get_linked_ids
+      |> Enum.map( &( get_name(&1) ) )
+      |> Enum.filter( &(&1) ) # remove nils
+      |> Enum.sort
   end
 
   @doc """

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -121,7 +121,7 @@ defmodule Populator.Helpers do
   """
   def start_child(spec, supervisor) do
     # Remove the child spec. We need the child_id
-    {child_id, _, _, _, _, _} = spec
+    child_id = elem(spec, 0)
     # Ignore the result (it's error the first time)
     Supervisor.delete_child supervisor, child_id
 

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -101,7 +101,7 @@ defmodule Populator.Helpers do
   end
 
   defp get_name(pid) do
-    Process.info(pid) |> Keyword.get :registered_name, nil
+    (Process.info(pid) || [])|> Keyword.get :registered_name, nil
   end
 
   @doc """

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -85,7 +85,7 @@ defmodule Populator.Helpers do
     name are not returned. List is sorted. Options al passed to `children_data/2`.
   """
   def children_names(supervisor) do
-		supervisor |> Supervisor.which_children |> Enum.map(fn (x) -> {name, _, _, _} = x; name end) |> Enum.sort
+    supervisor |> Supervisor.which_children |> Enum.map(fn (x) -> {name, _, _, _} = x; name end) |> Enum.sort
   end
 
   @doc """

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -120,6 +120,11 @@ defmodule Populator.Helpers do
     it was already started. `{:error, reason}` otherwise.
   """
   def start_child(spec, supervisor) do
+    # Remove the child spec. We need the child_id
+    {child_id, _, _, _, _, _} = spec
+    # Ignore the result (it's error the first time)
+    Supervisor.delete_child supervisor, child_id
+
     res = Supervisor.start_child supervisor, spec
     case child_is_started_ok(res) do
       false -> res

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -85,11 +85,7 @@ defmodule Populator.Helpers do
     name are not returned. List is sorted. Options al passed to `children_data/2`.
   """
   def children_names(supervisor) do
-    supervisor
-      |> get_linked_ids
-      |> Enum.map( &( get_name(&1) ) )
-      |> Enum.filter( &(&1) ) # remove nils
-      |> Enum.sort
+		supervisor |> Supervisor.which_children |> Enum.map(fn (x) -> {name, _, _, _} = x; name end) |> Enum.sort
   end
 
   @doc """

--- a/lib/populator.ex
+++ b/lib/populator.ex
@@ -32,14 +32,14 @@ defmodule Populator do
       and is_function(desired_children,1) do
 
     if opts[:stationary], do: :stationary,
-      else: populate(supervisor, child_spec, desired_children)
+      else: populate(supervisor, child_spec, desired_children, opts)
   end
 
   # Actually perform population operations
   #
-  defp populate(supervisor, child_spec, desired_children) do
+  defp populate(supervisor, child_spec, desired_children, opts) do
     # start all desired children
-    desired = desired_children.(supervisor)
+    desired = desired_children.(opts)
 
     for d <- desired do
       {:ok, _} = child_spec.(d) |> H.start_child(supervisor)

--- a/lib/populator.ex
+++ b/lib/populator.ex
@@ -28,7 +28,7 @@ defmodule Populator do
   """
   def run(supervisor, child_spec, desired_children, opts \\ [])
       when is_atom(supervisor)
-      and is_function(child_spec,1)
+      and is_function(child_spec,2)
       and is_function(desired_children,1) do
 
     if opts[:stationary], do: :stationary,
@@ -42,7 +42,7 @@ defmodule Populator do
     desired = desired_children.(opts)
 
     for d <- desired do
-      {:ok, _} = child_spec.(d) |> H.start_child(supervisor)
+      {:ok, _} = child_spec.(d, opts) |> H.start_child(supervisor)
     end
 
     # kill non desired ones
@@ -52,7 +52,7 @@ defmodule Populator do
     |> H.children_names
     |> Enum.filter(&( not(&1 in desired_names) ))
     |> Enum.each(fn (x) -> supervisor |> Supervisor.terminate_child(x); supervisor |> Supervisor.delete_child(x) end)
-		
+
     :ok
   end
 end

--- a/lib/populator.ex
+++ b/lib/populator.ex
@@ -48,7 +48,7 @@ defmodule Populator do
     # kill non desired ones
     desired_names = desired |> Enum.map(&( &1[:name] )) |> Enum.sort
 
-		supervisor
+    supervisor
     |> H.children_names
     |> Enum.filter(&( not(&1 in desired_names) ))
     |> Enum.each(fn (x) -> supervisor |> Supervisor.terminate_child(x); supervisor |> Supervisor.delete_child(x) end)

--- a/lib/populator.ex
+++ b/lib/populator.ex
@@ -35,6 +35,32 @@ defmodule Populator do
       else: populate(supervisor, child_spec, desired_children, opts)
   end
 
+  @doc """
+    This function has the same behaviour as run/4 but it builds the child_list
+    spect from this parameters:
+
+    * `child_spec` is a function returning the children spec. It recives
+      [name: name] and opts, the former being the desired children name,
+      the later being the worker params.
+    * `child_list` is actual process configuracion. It has the follwing structure:
+
+        child_list = [
+          [[name: :a], [value1: :v1a, value2: :v2a]],
+          [[name: :b], [value1: :v1b, value2: :v2b]]
+        ]
+
+    * `stationary` can be given to avoid the actual execution, useful on testing
+      environments, for example. `:stationary` will be returned.
+  """
+  def run_from_child_list(supervisor, child_spec, child_list, opts \\ [])
+    when is_atom(supervisor)
+    and is_function(child_spec, 2) do
+
+    if opts[:stationary], do: :stationary,
+      else: populate_from_child_list(supervisor, child_spec, child_list)
+
+  end
+
   # Actually perform population operations
   #
   defp populate(supervisor, child_spec, desired_children, opts) do
@@ -43,6 +69,27 @@ defmodule Populator do
 
     for d <- desired do
       {:ok, _} = child_spec.(d, opts) |> H.start_child(supervisor)
+    end
+
+    # kill non desired ones
+    desired_names = desired |> Enum.map(&( &1[:name] )) |> Enum.sort
+
+    supervisor
+    |> H.children_names
+    |> Enum.filter(&( not(&1 in desired_names) ))
+    |> Enum.each(fn (x) -> supervisor |> Supervisor.terminate_child(x); supervisor |> Supervisor.delete_child(x) end)
+
+    :ok
+  end
+
+  # Perform population operations from a child list
+  defp populate_from_child_list(supervisor, child_spec, child_list, opts \\ []) do
+    # start all desired children
+    desired = for [name, _] <- child_list, do: name
+    desired_params = for [name, params] <- child_list, do: [name, params]
+
+    for [d, p] <- desired_params do
+      {:ok, _} = child_spec.(d, p) |> H.start_child(supervisor)
     end
 
     # kill non desired ones

--- a/test/populator_test.exs
+++ b/test/populator_test.exs
@@ -47,16 +47,16 @@ defmodule PopulatorTest do
 
     # create supervisor, with some children
     initial_children_list  = [[name: :w1],[name: :w2],[name: :w3],[name: :w4],[name: :w5]]
-		initial_children_spec  = initial_children_list |> Enum.map(&( child_spec.(&1)))
-		initial_children_names = initial_children_list |> Enum.map &( &1[:name] )
-		{:ok, _} = TH.Supervisor.start_link children: initial_children_spec
+    initial_children_spec  = initial_children_list |> Enum.map(&( child_spec.(&1)))
+    initial_children_names = initial_children_list |> Enum.map &( &1[:name] )
+    {:ok, _} = TH.Supervisor.start_link children: initial_children_spec
 
     # check supervisor has the 5 children
     H.wait_for fn ->
       H.children_names(TH.Supervisor) == initial_children_names
     end
 
-		assert H.children_names(TH.Supervisor) == initial_children_names
+    assert H.children_names(TH.Supervisor) == initial_children_names
 
     # create desired_children function for 2 children
     desired_children = fn(_sup_name)->

--- a/test/populator_test.exs
+++ b/test/populator_test.exs
@@ -21,7 +21,7 @@ defmodule PopulatorTest do
     desired_names = desired_children.(desired_conf_id: :dummy) |> Enum.map &( &1[:name] )
 
     # create supervisor, with one random child already
-    {:ok, _} = TH.Supervisor.start_link children: [child_spec.(name: :w2)]
+    {:ok, _} = TH.Supervisor.start_link children: [child_spec.([name: :w2], opts: [])]
 
     # call Populator.run, it should populate with new children
     :ok = Populator.run TH.Supervisor, child_spec, desired_children
@@ -47,7 +47,7 @@ defmodule PopulatorTest do
 
     # create supervisor, with some children
     initial_children_list  = [[name: :w1],[name: :w2],[name: :w3],[name: :w4],[name: :w5]]
-    initial_children_spec  = initial_children_list |> Enum.map(&( child_spec.(&1)))
+    initial_children_spec  = initial_children_list |> Enum.map(&( child_spec.(&1, opts: [])))
     initial_children_names = initial_children_list |> Enum.map &( &1[:name] )
     {:ok, _} = TH.Supervisor.start_link children: initial_children_spec
 
@@ -89,7 +89,7 @@ defmodule PopulatorTest do
     {child_spec, desired_children} = get_growth_funs
 
     # create supervisor, with one random child already
-    {:ok, _} = TH.Supervisor.start_link children: [child_spec.(name: :w2)]
+    {:ok, _} = TH.Supervisor.start_link children: [child_spec.([name: :w2], opts: [])]
 
     # save linked_ids to ensure they are steady
     linked_ids = H.get_linked_ids TH.Supervisor
@@ -161,7 +161,7 @@ defmodule PopulatorTest do
 
   # create child_spec function
   defp get_child_spec_fun do
-    fn(data)->
+    fn(data, _opts)->
       Supervisor.Spec.worker(Task,
                              [TH, :lazy_worker, [[ name: data[:name] ]] ],
                              [id: data[:name], restart: :temporary])

--- a/test/populator_test.exs
+++ b/test/populator_test.exs
@@ -18,7 +18,7 @@ defmodule PopulatorTest do
   test "population growth" do
     # get funs
     {child_spec, desired_children} = get_growth_funs
-    desired_names = desired_children.(:dummy_sup_name) |> Enum.map &( &1[:name] )
+    desired_names = desired_children.(desired_conf_id: :dummy) |> Enum.map &( &1[:name] )
 
     # create supervisor, with one random child already
     {:ok, _} = TH.Supervisor.start_link children: [child_spec.(name: :w2)]
@@ -62,7 +62,7 @@ defmodule PopulatorTest do
     desired_children = fn(_sup_name)->
       [[name: :w3],[name: :w5]]
     end
-    desired_names = desired_children.(:dummy_sup_name) |> Enum.map &( &1[:name] )
+    desired_names = desired_children.(desired_conf_id: :dummy) |> Enum.map &( &1[:name] )
 
     # call Populator.run, it should kill some children
     :ok = Populator.run TH.Supervisor, child_spec, desired_children
@@ -152,7 +152,7 @@ defmodule PopulatorTest do
   # get child_spec_fun and desired_children_fun for growth test
   defp get_growth_funs do
     # create desired_children function for 5 children
-    desired_children = fn(_sup_name)->
+    desired_children = fn(_opts)->
       [[name: :w1],[name: :w2],[name: :w3],[name: :w4],[name: :w5]]
     end
 

--- a/test/populator_test.exs
+++ b/test/populator_test.exs
@@ -18,7 +18,7 @@ defmodule PopulatorTest do
   test "population growth" do
     # get funs
     {child_spec, desired_children} = get_growth_funs
-    desired_names = desired_children.() |> Enum.map &( &1[:name] )
+    desired_names = desired_children.(:dummy_sup_name) |> Enum.map &( &1[:name] )
 
     # create supervisor, with one random child already
     {:ok, _} = TH.Supervisor.start_link children: [child_spec.(name: :w2)]
@@ -51,10 +51,10 @@ defmodule PopulatorTest do
     {:ok, _} = TH.Supervisor.start_link children: children
 
     # create desired_children function for 2 children
-    desired_children = fn()->
+    desired_children = fn(_sup_name)->
       [[name: :w3],[name: :w5]]
     end
-    desired_names = desired_children.() |> Enum.map &( &1[:name] )
+    desired_names = desired_children.(:dummy_sup_name) |> Enum.map &( &1[:name] )
 
     # call Populator.run, it should kill some children
     :ok = Populator.run TH.Supervisor, child_spec, desired_children
@@ -142,7 +142,7 @@ defmodule PopulatorTest do
   # get child_spec_fun and desired_children_fun for growth test
   defp get_growth_funs do
     # create desired_children function for 5 children
-    desired_children = fn()->
+    desired_children = fn(_sup_name)->
       [[name: :w1],[name: :w2],[name: :w3],[name: :w4],[name: :w5]]
     end
 

--- a/test/populator_test.exs
+++ b/test/populator_test.exs
@@ -149,6 +149,72 @@ defmodule PopulatorTest do
     end
   end
 
+  test "Populator from child list" do
+
+    # Build a list of children with its parameters
+    child_list = [
+      [[name: :a], [value1: :v1a, value2: :v2a]],
+      [[name: :b], [value1: :v1b, value2: :v2b]]
+    ]
+
+    {:ok, _} = TH.Supervisor.start_link children: []
+
+    # The task to do
+    child_spec = get_child_spec_fun_for_child_list(self)
+
+    :ok = Populator.run_from_child_list TH.Supervisor, child_spec, child_list
+
+    # Wait for the two children
+    H.wait_for fn ->
+      H.children_names(TH.Supervisor) == [:a, :b]
+    end
+
+    # Check the children received and sent the right values
+    1..2 |> Enum.each fn(_) ->
+      ret = receive do
+        {:a, :v1a, :v2a} -> :ok
+        {:b, :v1b, :v2b} -> :ok
+      end
+
+      assert ret == :ok
+    end
+  end
+
+  test "Populator from child list (shrinks)" do
+
+    child_spec = get_child_spec_fun
+    initial_children_list  = [[name: :w1],[name: :w2],[name: :w3],[name: :w4],[name: :w5]]
+    initial_children_spec  = initial_children_list |> Enum.map(&( child_spec.(&1, opts: [])))
+
+    {:ok, _} = TH.Supervisor.start_link children: initial_children_spec
+
+    # Build a list of children with its parameters
+    child_list = [
+      [[name: :a], [value1: :v1a, value2: :v2a]],
+      [[name: :b], [value1: :v1b, value2: :v2b]]
+    ]
+
+    # The task to do
+    child_spec = get_child_spec_fun_for_child_list(self)
+
+    :ok = Populator.run_from_child_list TH.Supervisor, child_spec, child_list
+
+    # Wait for the two children
+    H.wait_for fn ->
+      H.children_names(TH.Supervisor) == [:a, :b]
+    end
+
+    # Check the children received and sent the right values
+    1..2 |> Enum.each fn(_) ->
+      ret = receive do
+        {:a, :v1a, :v2a} -> :ok
+        {:b, :v1b, :v2b} -> :ok
+      end
+
+      assert ret == :ok
+    end
+  end
+
   # get child_spec_fun and desired_children_fun for growth test
   defp get_growth_funs do
     # create desired_children function for 5 children
@@ -165,6 +231,24 @@ defmodule PopulatorTest do
       Supervisor.Spec.worker(Task,
                              [TH, :lazy_worker, [[ name: data[:name] ]] ],
                              [id: data[:name], restart: :temporary])
+    end
+  end
+
+  defp get_child_spec_fun_for_child_list(parent) do
+    fn([name: name], opts) ->
+      task = fn ->
+
+        # Very imporant when working with populator
+        Process.register self, name
+
+        # Send the received values to the parent
+        send parent, {name, opts[:value1], opts[:value2]}
+
+        # This sleep is need by the wait_for call (see below)
+        :timer.sleep 2000
+      end
+
+      Supervisor.Spec.worker(Task, [task], [name: name, id: name, restart: :temporary])
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,7 +5,7 @@ defmodule Populator.TestHelpers.Supervisor do
 
   def start_link(args \\ []), do: Supervisor.start_link(__MODULE__, [args], name: __MODULE__)
 
-  def init(args) do
+  def init([args]) do
     args = [children: [], max_restarts: 3, max_seconds: 5] |> Keyword.merge args
 
     supervise(args[:children], strategy: :one_for_one,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -23,4 +23,9 @@ defmodule Populator.TestHelpers do
     lazy_worker
   end
 
+  def one_time_worker(opts \\ []) do
+    if opts[:name], do: Process.register(self,opts[:name])
+    :timer.sleep(1_000)
+  end
+
 end


### PR DESCRIPTION
There are two changes. The first one is the way children processes are removed from the supervisor.

The second one passes the supervisor's name to the *desired_children* function which becomes an arity 1 function. This way it's possible to group populator's callback functions in the same module and receive the supervisor name in order to find the new supervisor configuration.

For example, in this test the supervisor configuration is kept in an ETS and modified several times.

```Elixir
	test "The runner grows and shrinks" do
		sup_name = :sup4
		
		{:ok, _} = Rec.SupervisorUno.start_link(sup_name)

		# Changes the processes's configuration.
		Rec.SupervisorUno.set_desired_processes(sup_name, [[name: "worker_uno"],
                                                           [name: "worker_dos"]])

		wait_for_processes
		
		# Supervisor callbacks.
		run_args = [sup_name, &Rec.SupervisorUno.supervisor_uno_child_spec/1,
                              &Rec.SupervisorUno.supervisor_uno_desired_children/1]

		# Looper configuration.
		args = [step: 1000, max_loops: 15, name: :test_looper, run_args: run_args]

		# Run the loop.
		Task.async(fn -> :ok = Populator.Looper.run(args) end)

		wait_for_processes
		
		# Check for two processes.
		assert 2 == Supervisor.which_children(sup_name) |> length

		# Check for four processes.
		Rec.SupervisorUno.set_desired_processes(sup_name, [[name: "worker_uno"],
                                                           [name: "worker_dos"],
																						           [name: "worker_tres"], [name: "worker_cuatro"]])

		wait_for_processes

		assert 4 == Supervisor.which_children(sup_name) |> length

		# Check for no process at all.
		Rec.SupervisorUno.set_desired_processes(sup_name, [])
		wait_for_processes

		assert 0 == Supervisor.which_children(sup_name) |> length
	end
```

The supervisor is.

```Erlang
defmodule Rec.SupervisorUno do
	use Supervisor

	def start_link(name) do
		:ets.new(name, [:set, :named_table, :public])
		
		Supervisor.start_link(__MODULE__, [], [name: name])
	end
	
	def init([]) do
		children = []

		supervise(children, strategy: :one_for_one)
	end

	def supervisor_uno_child_spec(opts) do
		name = opts[:name]
		Supervisor.Spec.worker(Rec.WorkerUno, [opts], [id: name])
	end

	def supervisor_uno_desired_children(name) do
		get_desired_processes(name)
	end

	def set_desired_processes(name, desired_processes) do
		:ets.insert(name, {:all, desired_processes})
	end

	def get_desired_processes(name) do
		[all: desired_processes] = :ets.lookup(name, :all)
		desired_processes
	end
end
```

If the change is ok the configuration will be updated.

thx
